### PR TITLE
Add browser-specific user-select properties.

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -199,7 +199,7 @@ getPasteR pid = do
 <style>
   table { font-family: monospace }
   table td { white-space: pre }
-  td > a { color: #aaa; text-decoration: none; display: block; padding-right: 1em; user-select: none; }
+  td > a { color: #aaa; text-decoration: none; display: block; padding-right: 1em; user-select: none; -webkit-user-select: none; -moz-user-select: none; -ms-user-select: none; }
   .OtherTok, .CommentTok { color: #8e908c }
   .KeywordTok { color: #8959a8 }
   .DataTypeTok { color: #4271ae }


### PR DESCRIPTION
Fixes an issue where Firefox does not respect the `user-select: none;` property for line numbers (which seems like a bug, as Mozilla claims to support `user-select` since Firefox 21!). I added the same set of user-select properties used by github gist:

- `-webkit-user-select: none;`
- `-moz-user-select: none;`
- `-ms-user-select: none;`